### PR TITLE
Fix compilation

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -20,13 +20,6 @@ inline float sign(float f)
 	return f<0.0f?-1.0f:1.0f;
 }
 
-inline int round(float f)
-{
-	if(f > 0)
-		return (int)(f+0.5f);
-	return (int)(f-0.5f);
-}
-
 template<typename T, typename TB>
 inline T mix(const T a, const T b, TB amount)
 {


### PR DESCRIPTION
### Fix compilaton
* This PR changes the code so the compilation works, some teeworlds mods a very old version of C. Newer version conflicts with math functions created by teeworlds, since they're now native, so removing them makes the compilation works again.